### PR TITLE
Remove unf warning

### DIFF
--- a/mulder.gemspec
+++ b/mulder.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'isomer', '~> 0.1.3'
   spec.add_dependency 'thor', '~> 0.18.1'
   spec.add_dependency 'awesome_print', '~> 1.1.0'
+  spec.add_dependency 'unf', '~> 0.1.4'
 end


### PR DESCRIPTION
The warning that the 'unf' gem could not be loaded can be easily fixed by explicitly making 'unf' a dependency for mulder.

See http://stackoverflow.com/questions/19666226/warning-with-fog-and-aws-unable-to-load-the-unf-gem for info.
