### PR TITLE
[Daanemanz] Include prefix in application name

### DIFF
--- a/lib/mulder/client.rb
+++ b/lib/mulder/client.rb
@@ -19,7 +19,7 @@ module Mulder
     end
 
     def id_regexp
-      /^.*-?#{@app}-#{@environment}-(.*-)?#{@role}-.*$/i
+      /^#{@app}-#{@environment}-(.*-)?#{@role}-.*$/i
     end
 
   end

--- a/spec/lib/mulder/client_spec.rb
+++ b/spec/lib/mulder/client_spec.rb
@@ -17,7 +17,7 @@ describe Mulder::Client do
   describe '#group' do
     it 'finds the correct group based on the given attributes' do
       mocked_connection = mock
-      mocked_connection.expects(:group_by_id_regexp).with(/^.*-?foo-bar-(.*-)?WorkerGroup-.*$/i)
+      mocked_connection.expects(:group_by_id_regexp).with(/^foo-bar-(.*-)?WorkerGroup-.*$/i)
       client = described_class.new(mocked_connection, 'foo', 'bar', 'WorkerGroup')
 
       client.group
@@ -47,9 +47,28 @@ describe Mulder::Client do
       'foo-bar-abc123-worker-3'.should match(client.id_regexp)
     end
 
-    it 'matches with a prefixed id' do
-      client = described_class.new(mock, 'foo', 'bar', 'worker')
-      'widget-foo-bar-abd123-worker-8'.should match(client.id_regexp)
+    context 'with prefixed id' do
+      let(:client) { described_class.new(mock, 'widget-foo', 'bar', 'worker') }
+
+      it 'matches the prefixed group' do
+        'widget-foo-bar-abd123-worker-8'.should match(client.id_regexp)
+      end
+
+      it 'does not match the non-prefixed group' do
+        'foo-bar-derp456-worker-99'.should_not match(client.id_regexp)
+      end
+    end
+
+    context 'with non-prefixed id' do
+      let(:client) { described_class.new(mock, 'foo', 'bar', 'worker') }
+
+      it 'does not match the prefixed group' do
+        'widget-foo-bar-abd123-worker-8'.should_not match(client.id_regexp)
+      end
+
+      it 'matches the non-prefixed group' do
+        'foo-bar-derp456-worker-99'.should match(client.id_regexp)
+      end
     end
   end
 


### PR DESCRIPTION
Require including prefix in application name
Previously, when searching for instances in autoscaling groups with application `foo`, environment `bar` and group `workers` would return results from groups with names like

`foo-bar-X123-workers-Z456`

and

`widget-foo-bar-X789-workers-A321`

This could potentially be confusing when results from the two groups should be treated entirely different.

When the CloudFormation stack has a prefix in the name like the second example above, it is now mandatory to include such a prefix in the application name when searching for autoscaling instances or when using `mulder` with Capistrano.

For a CloudFormation stack for application `fop-foo` with environment `bar` and an AutoScaling group with `webservers` in the name:

``` ruby
set :aws_creds,     'config/aws.yml'
set :stack_name,    'fop-foo'
set :rails_env,     'bar'
set(:mulder)        { Mulder::Capistrano.new(aws_creds, stack_name, rails_env) }

role(:web)    { mulder.ips('webservers', true) }
```

```
$ mulder search fop-foo bar webservers
```

Both will return instances from an autoscaling group called `fop-foo-bar-X123-webservers-Y456`, but not from the group `foo-bar-X123-webservers-Y456`.
