### PR TITLE
Upgrade Thor to ease Bundler dependency resolution

### DIFF
--- a/mulder.gemspec
+++ b/mulder.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'fog', '~> 1.20.0'
   spec.add_dependency 'isomer', '~> 0.1.3'
-  spec.add_dependency 'thor', '~> 0.18.1'
+  spec.add_dependency 'thor', '~> 0.19.1'
   spec.add_dependency 'awesome_print', '~> 1.1.0'
   spec.add_dependency 'unf', '~> 0.1.4'
 end


### PR DESCRIPTION
Reports of upgrades to development tools like Foreman, Rubocop _etc_ being blocked by the current version of Mulder pinning Thor to '~> 0.18.1' where those tools have dependency chains involving Thor 0.19.x.

Upgrade the development dependency for Mulder to use Thor 0.19, the current version.
