### PR TITLE
Stop unhealthy instances from being returned by default

### DIFF
--- a/lib/mulder/client.rb
+++ b/lib/mulder/client.rb
@@ -15,7 +15,7 @@ module Mulder
     end
 
     def instances
-      @connection.instances_by_group(group)
+      @connection.instances_by_group(group).select(&:exists?)
     end
 
     def id_regexp

--- a/lib/mulder/instance.rb
+++ b/lib/mulder/instance.rb
@@ -37,6 +37,10 @@ module Mulder
       @fog_compute_instance.created_at
     end
 
+    def exists?
+      !@fog_compute_instance.nil?
+    end
+
     def as_hash
       @as_hash ||= {
         id: id,

--- a/spec/lib/mulder/client_spec.rb
+++ b/spec/lib/mulder/client_spec.rb
@@ -25,10 +25,36 @@ describe Mulder::Client do
   end
 
   describe '#instances' do
+    let(:mocked_connection) { mock }
+    let(:mocked_group) { mock }
+    let(:client) { described_class.new(mocked_connection, 'foo', 'bar', 'worker') }
+    let(:instances) { [] }
+
+    before do
+      mocked_connection.stubs(:instances_by_group).with(mocked_group).returns(instances)
+      client.stubs(:group).returns(mocked_group)
+    end
+
+    context 'when there are no unhealthy instances' do
+      let(:instances) {[mock('healthy instance', exists?: true), mock('healthy instance', exists?: true)]}
+
+      it 'returns all instances' do
+        client.instances.size.should == 2
+      end
+    end
+
+    context 'when there are unhealthy instances' do
+      let(:instances) { [mock('healthy instance', exists?: true), mock('unhealthy instance', exists?: false)] }
+
+      it 'returns only the healthy ones' do
+        client.instances.size.should == 1
+      end
+    end
+
     it 'finds the instances for the group' do
       mocked_connection = mock
       mocked_group = mock
-      mocked_connection.expects(:instances_by_group).with(mocked_group)
+      mocked_connection.expects(:instances_by_group).with(mocked_group).returns([])
       client = described_class.new(mocked_connection, 'foo', 'bar', 'worker')
       client.expects(:group).returns(mocked_group)
 

--- a/spec/lib/mulder/instance_spec.rb
+++ b/spec/lib/mulder/instance_spec.rb
@@ -11,6 +11,21 @@ describe Mulder::Instance do
     end
   end
 
+  describe '#exists?' do
+    context 'when there is a compute instance' do
+      it 'returns true' do
+        fog_compute_instance = mock
+        described_class.new(fog_compute_instance).should exist
+      end
+    end
+
+    context 'when there no compute instance' do
+      it 'returns false' do
+        described_class.new(nil).should_not exist
+      end
+    end
+  end
+
   describe '#as_hash' do
     let(:instance) { mock(attributes) }
 


### PR DESCRIPTION
It seems that an Autoscaling Group can return an instance that won't return an instance from the EC2 lookup. It is labeled in the console as "unhealthy" currently. This should just exclude those instances. I also changed the API to reflect that this method includes only healthy instances.

/cc @itsmeduncan 